### PR TITLE
fixed `cancel()` being called on wrong `future`

### DIFF
--- a/src/callable_example/ResultCheckerExample.java
+++ b/src/callable_example/ResultCheckerExample.java
@@ -21,6 +21,13 @@ public class ResultCheckerExample implements Runnable {
             for (Iterator<RunnableFuture<Integer>> futureIterator = runnableFutureList.iterator(); futureIterator.hasNext(); ) {
                 RunnableFuture<Integer> future = futureIterator.next();
 
+                if (completedTask == 2) {
+                    completedTask++;
+                    future.cancel(true);
+                    System.out.println("Задача остановлена, результат её работы не требуется");
+                    break;
+                }
+
                 if (future.isDone()) {
                     completedTask++;
                     try {
@@ -31,11 +38,7 @@ public class ResultCheckerExample implements Runnable {
                     }
                 }
 
-                if (completedTask == 2) {
-                    completedTask++;
-                    future.cancel(true);
-                    System.out.println("Задача остановлена, результат её работы не требуется");
-                }
+
             }
 
         }


### PR DESCRIPTION
so the third task would in fact run until completion. refactored to make sure that `cancel()` is called on the right `future` and the task that needs to be cancelled is indeed canceled.